### PR TITLE
fix: 修复训练流删除不成功时的提示内容错误

### DIFF
--- a/apps/platform/src/modules/pipeline/pipeline-menu.tsx
+++ b/apps/platform/src/modules/pipeline/pipeline-menu.tsx
@@ -80,6 +80,9 @@ export const PipelineMenu = (prop: {
       if (msg) message.success(msg);
     } catch (e) {
       console.error(e);
+      // 显示错误消息给用户
+      const errorMessage = e instanceof Error ? e.message : '操作失败';
+      message.error(errorMessage);
     }
   };
   return (

--- a/apps/platform/src/modules/pipeline/pipeline-service.ts
+++ b/apps/platform/src/modules/pipeline/pipeline-service.ts
@@ -290,10 +290,15 @@ export class DefaultPipelineService extends Model {
     const { search } = window.location;
     const { projectId } = parse(search);
 
-    await deleteGraph({
+    const response = await deleteGraph({
       projectId: projectId as string,
       graphId: pipelineId,
     });
+    // 检查API响应状态
+    if (response.status && response.status.code !== 0) {
+      throw new Error(response.status.msg || '删除失败');
+    }
+    return response;
   }
 
   async renamePipeline(pipelineId: string, name: string) {


### PR DESCRIPTION
### Description 描述

此PR是为了修复：训练流删除不成功时，前端页面仍提示删除成功问题。

问题定位：目前前端没有处理训练流删除失败的逻辑，所以导致即使删除失败，也提示删除成功。

修复方法：修改了对于后端请求 /api/v1alpha1/graph/delete 响应结果的处理。当后端接口响应的状态码非0，将抛出异常。上层方法之前就有捕获异常的，新增捕获异常后处理：接口返回msg信息作为前端页面提示的内容。

本地修复后运行效果：
<img width="2511" height="314" alt="06ee5b27a8f25ff0dfd40cd6858d7893" src="https://github.com/user-attachments/assets/18374407-dfba-4b4c-85d4-7f5c12443121" />

### Related issues 相关 issues
关联issue：#44 


### Changes 涉及的变更

<!-- Please choose all that applies ->
<!-- 请选择一个或者多个合适的描述 -->

- [ ] Breaking changes 不向后兼容的变化
- [ ] Documentation changes 文档更新
- [X] Bugfixes 缺陷修复
- [ ] New features 新功能
- [ ] Refactoring 代码重构
- [ ] Dependencies upgrade 依赖版本升级
- [ ] Tooling changes 工具链变更
- [ ] Other changes 其它变更



